### PR TITLE
Fix example of nmap plugin

### DIFF
--- a/lib/ansible/plugins/inventory/nmap.py
+++ b/lib/ansible/plugins/inventory/nmap.py
@@ -47,7 +47,7 @@ EXAMPLES = '''
     # inventory.config file in YAML format
     plugin: nmap
     strict: False
-    network: 192.168.0.0/24
+    address: 192.168.0.0/24
 '''
 
 import os


### PR DESCRIPTION
##### SUMMARY
nmap example contains invalid network option, it must be address.

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
nmap

##### ANSIBLE VERSION
2.6.1
```

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
